### PR TITLE
Update the recommended VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["vue.volar"]
 }


### PR DESCRIPTION
The official vue volar extension changed a bit. It's now https://marketplace.visualstudio.com/items?itemName=Vue.volar , and no longer needs the vscode-typescript-vue-plugin